### PR TITLE
feat: 内场组相关机制

### DIFF
--- a/Dawntrail/Cloud_of_Darkness_Chaotic.cs
+++ b/Dawntrail/Cloud_of_Darkness_Chaotic.cs
@@ -62,7 +62,7 @@ namespace KDrawScript.Dev
         private List<(ulong, string)> Embrace = [];
         private string DelayWhat = string.Empty;
         private bool HaveLoomingChaos = false;
-        private bool HasShownMemberIdx = false;、
+        private bool HasShownMemberIdx = false;
         private readonly List<Vector3> FlarePoint = [new(72, 0, 76), new(100, 0, 103), new(126, 0, 76)];
         private readonly List<Vector3> SeedPoint = [new(0, 0, 0), new(70, 0, 92), new(70, 0, 107), new(130, 0, 108), new(130, 0, 92)]; // Only A, C Party Each have two points
         private readonly Object SeedLock = new();
@@ -813,7 +813,7 @@ namespace KDrawScript.Dev
             dp.Scale = new Vector2(40);
             dp.InnerScale = new Vector2(34);
             dp.Radian = float.Pi * 2;
-            dp.Position = new Vector3(100, 0, 100);
+            dp.Position = Center;
             dp.Color = sa.Data.DefaultDangerColor;
             dp.Delay = 0;
             dp.DestoryAt = 5000;
@@ -1137,12 +1137,12 @@ namespace KDrawScript.Dev
                 // 获得玩家所在四角方位
                 var myChara = sa.Data.MyObject;
                 if (myChara == null) return;
-                var myDir = Position2Dirs(myChara.Position, new Vector3(100, 0, 100), 4, false);
+                var myDir = Position2Dirs(myChara.Position, Center, 4, false);
                 
                 // 获得目标所在四角方位
                 IPlayerCharacter? tchara = (IPlayerCharacter?)sa.Data.Objects.SearchById(ev.TargetId);
                 if (tchara == null) return;
-                var targetDir = Position2Dirs(tchara.Position, new Vector3(100, 0, 100), 4, false);
+                var targetDir = Position2Dirs(tchara.Position, Center, 4, false);
                 
                 // 如果玩家与目标所在方位不同，忽略
                 if (targetDir != myDir) return;
@@ -1190,7 +1190,7 @@ namespace KDrawScript.Dev
         {
             // 基准点，选取为方位0（右上）优先级低（近）点。
             Vector3 seedPlacePos = new Vector3(113.5f, 0f, 95.5f);
-            Vector3 center = new Vector3(100, 0, 100);
+            Vector3 center = Center;
             
             // 在另一侧则中心翻转
             if (dir >= 2)

--- a/Dawntrail/Cloud_of_Darkness_Chaotic.cs
+++ b/Dawntrail/Cloud_of_Darkness_Chaotic.cs
@@ -1,6 +1,7 @@
 ﻿using ECommons;
 using ECommons.MathHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.Group;
+using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Common.Math;
 using KodakkuAssist.Extensions;
 using KodakkuAssist.Module.Draw;
@@ -13,10 +14,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using KodakkuAssist.Module.Draw.Manager;
 using Dalamud.Utility.Numerics;
+using KodakkuAssist.Data;
 
 namespace KDrawScript.Dev
 {
-    [ScriptType(name: "CoD (Chaotic) 暗黑之云诛灭战", territorys: [1241], guid: "436effd2-a350-4c67-b341-b4fe5a4ac233", version: "0.0.1.2", author: "Due", note: NoteStr)]
+    [ScriptType(name: "CoD (Chaotic) 暗黑之云诛灭战", territorys: [1241], guid: "436effd2-a350-4c67-b341-b4fe5a4ac233", version: "0.0.1.2", author: "Due", note: NoteStr, updateInfo: UpdateInfo)]
     public class Cloud_of_Darkness_Chaotic
     {
         private const string NoteStr =
@@ -25,6 +27,28 @@ namespace KDrawScript.Dev
         仅有计划做 A/C 队 D2 - 4 指路 （即固定换到对方平台组）
         若发生问题请携ARR反馈。
         """;
+        
+        private const string UpdateInfo =
+            """
+            1. 修复了P3小云正侧炮。
+            2. B队添加放种子前预占位，其余功能开发中。
+            """;
+        
+        private const bool Debugging = false;
+        private const bool ReplayGroup = false;
+        
+        private static List<string> _role = ["MT", "ST", "H1", "H2", "D1", "D2", "D3", "D4"];
+        private static List<string> _alliance = ["A", "B", "C"];
+        private int _partyMemberIdx = -1;
+        private enum CodPhase
+        {
+            Init,
+            Diamond,
+            Tilt,
+            // Exchange,    // 弃用，可以使用 bool HaveLoomingChaos;
+        }
+
+        private CodPhase _codPhase = CodPhase.Init;
 
         private List<(ulong, string)> Embrace = [];
         private string DelayWhat = string.Empty;
@@ -67,6 +91,7 @@ namespace KDrawScript.Dev
 
         public void Init(ScriptAccessory accessory)
         {
+            _codPhase = CodPhase.Init;
             Embrace.Clear();
             DelayWhat = string.Empty;
             HaveLoomingChaos = false;
@@ -75,12 +100,114 @@ namespace KDrawScript.Dev
             EverDrawPhaser = false;
             accessory.Method.RemoveDraw(".*");
         }
+        
+        #region TestRegion
+        
+        [ScriptMethod(name: "---- 测试项 ----", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
+            userControl: Debugging)]
+        public void SplitLine_TestRegion(Event ev, ScriptAccessory sa)
+        {
+        }
+        
+        [ScriptMethod(name: "测试 我在内场还是外场", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
+            userControl: Debugging)]
+        public void LocateAtWhichPlatform(Event ev, ScriptAccessory sa)
+        {
+            var str = "";
+            str += $"{(IsOnInnerPlatform(sa, sa.Data.Me) ? "在内场" : "不在内场")}";
+            str += $"{(IsOnSidePlatform(sa, sa.Data.Me) ? "在外场" : "不在外场")}";
+            sa.Log.Debug(str);
+        }
+        
+        [ScriptMethod(name: "测试 我是谁", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
+            userControl: Debugging)]
+        public void WhoAmI(Event ev, ScriptAccessory sa)
+        {
+            var myMemberIdx = GetMemberIdx(sa);
+            sa.Log.Debug($"你的身份为，【{_alliance[myMemberIdx / 10]} 队 {_role[myMemberIdx % 10]}】");
+        }
+        
+        [ScriptMethod(name: "测试 获得内场玩家", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
+            userControl: Debugging)]
+        public void PrintInnerPlatformPlayers(Event ev, ScriptAccessory sa)
+        {
+            var players = GetInnerPlatformPlayers(sa);
+            List<string> jobString = ["Tank", "Healer", "Dps"];
+            sa.Log.Debug($"====== 内场玩家：======");
+            foreach (var player in players)
+            {
+                sa.Log.Debug(
+                    $"{player.Key}, 同组 {player.Value.Item1}, 职能 {jobString[player.Value.Item2]}," +
+                    $" {player.Value.Item3}, eid {player.Value.Item4:x8}, 位置 {player.Value.Item5}");
+            }
+        }
+        
+        [ScriptMethod(name: "测试 获得外场玩家", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
+            userControl: Debugging)]
+        public void PrintSidePlatformPlayers(Event ev, ScriptAccessory sa)
+        {
+            var players = GetSidePlatformPlayers(sa);
+            List<string> jobString = ["Tank", "Healer", "Dps"];
+            sa.Log.Debug($"====== 外场玩家：======");
+            foreach (var player in players)
+            {
+                sa.Log.Debug(
+                    $"{player.Key}, 同组 {player.Value.Item1}, 职能 {jobString[player.Value.Item2]}," +
+                    $" {player.Value.Item3}, eid {player.Value.Item4:x8}, 位置 {player.Value.Item5}");
+            }
+        }
+        
+        [ScriptMethod(name: "测试 翻转大云可选中状态", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
+            userControl: Debugging)]
+        public unsafe void ToggleCloudsTargetable(Event ev, ScriptAccessory sa)
+        {
+            var cloudCharaEnum = sa.Data.Objects.GetByDataId(0x461e);
+            List<IGameObject> cloudCharaList = cloudCharaEnum.ToList();
+            sa.Log.Debug($"获得 {cloudCharaList.Count} 个 0x461e 实体，为大云。");
+            if (cloudCharaList.Count != 1) return;
+
+            var cloudChara = cloudCharaList[0];
+            SetTargetable(sa, cloudChara, !cloudChara.IsTargetable);
+            sa.Log.Debug($"已翻转大云可选中状态。");
+        }
+        
+        [ScriptMethod(name: "测试 翻转小云可选中状态", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
+            userControl: Debugging)]
+        public unsafe void ToggleShadowsTargetable(Event ev, ScriptAccessory sa)
+        {
+            var shadowCharaEnum = sa.Data.Objects.GetByDataId(0x461f);
+            List<IGameObject> shadowCharaList = shadowCharaEnum.ToList();
+            sa.Log.Debug($"获得 {shadowCharaList.Count} 个 0x461f 实体，为小云。");
+            if (shadowCharaList.Count != 2) return;
+
+            foreach (var shadowChara in shadowCharaList)
+                SetTargetable(sa, shadowChara, !shadowChara.IsTargetable);
+            sa.Log.Debug($"已翻转小云可选中状态。");
+        }
+        
+        #endregion TestRegion
+        
         #region P1
         
         [ScriptMethod(name: "---- Phase Diamond ----", eventType: EventTypeEnum.NpcYell, eventCondition: ["HelloayaWorld"],
             userControl: true)]
         public void SplitLine_Phase2(Event ev, ScriptAccessory sa)
         {
+        }
+        
+        [ScriptMethod(name: "阶段转换 - 钻石", eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:40509"],
+            userControl: Debugging)]
+        public void PhaseChange_P2(Event ev, ScriptAccessory sa)
+        {
+            _codPhase = CodPhase.Diamond;
+            sa.Log.Debug($"当前阶段为：{_codPhase}");
+            var partyMemberIdxNew = GetMemberIdx(sa);
+            if (_partyMemberIdx != partyMemberIdxNew)
+            {
+                _partyMemberIdx = partyMemberIdxNew;
+                sa.Method.TextInfo($"你的身份为，【{_alliance[partyMemberIdxNew / 10]}队{_role[partyMemberIdxNew % 10]}】，若有误请及时于【用户设置】调整。",
+                    5000, false);
+            }
         }
         
         [ScriptMethod(name: "Blade of Darkness 左右小月环及钢铁", eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:regex:^(4044[468])$"])]
@@ -117,9 +244,10 @@ namespace KDrawScript.Dev
             }
         }
 
-        [ScriptMethod(name: "AOE 提醒", eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:regex:^(40509|40510|40456)$"])]
+        [ScriptMethod(name: "AOE 提醒", eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:regex:^(40510|40456)$"])]
         public void DelugeofDarkness(Event @event, ScriptAccessory accessory)
         {
+            // Usami: 我把 [40509 暗之泛滥] AOE提醒的部分改成了玩家身份提醒，按理说AOE应该不会忘吧！
             SendText("AOE", accessory);
         }
 
@@ -461,6 +589,21 @@ namespace KDrawScript.Dev
         {
         }
         
+        [ScriptMethod(name: "阶段转换 - 三重", eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:40449"],
+            userControl: false)]
+        public void PhaseChange_P3(Event ev, ScriptAccessory sa)
+        {
+            _codPhase = CodPhase.Tilt;
+            sa.Log.Debug($"当前阶段为：{_codPhase}");
+            var partyMemberIdxNew = GetMemberIdx(sa);
+            if (_partyMemberIdx != partyMemberIdxNew)
+            {
+                _partyMemberIdx = partyMemberIdxNew;
+                sa.Method.TextInfo($"你的身份为，【{_alliance[partyMemberIdxNew / 10]}队{_role[partyMemberIdxNew % 10]}】，若有误请及时于【用户设置】调整。",
+                    5000, false);
+            }
+        }
+        
         [ScriptMethod(name: "初始位置", eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:40449"],
         userControl: true)]
         public void P3InitField(Event ev, ScriptAccessory sa)
@@ -727,7 +870,71 @@ namespace KDrawScript.Dev
                     break;
             }
         }
+        
+        [ScriptMethod(name: "Evil Seed Prepared Position 场内放种子前就位", 
+            eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:40490"],
+            suppress: 10000, userControl: true)]
+        public void EvilSeedPreparedPosition(Event ev, ScriptAccessory sa)
+        {
+            if (_codPhase != CodPhase.Tilt) return;
+            
+            // suppress 10000，该技能为场边两只小云的读条，避免执行两次
+            var myMemberIdx = GetMemberIdx(sa);
+            if (myMemberIdx == -1)
+            {
+                sa.Log.Debug($"获得MemberIdx错误，可能该目标非我队队员");
+                return;
+            }
+            
+            // 获得玩家状态，是否带有InnerDarkness状态
+            if (!IsOnInnerPlatform(sa, sa.Data.Me))
+            {
+                sa.Log.Debug($"玩家不在场中平台上，真可怜！");
+                return;
+            }
+            
+            Vector3 readyPos = myMemberIdx switch
+            {
+                10 => GetBlockField(7, 3),  // B-MT
+                11 => GetBlockField(7, 6),  // B-ST
+                12 => GetBlockField(7, 1),  // B-H1
+                13 => GetBlockField(7, 8),  // B-H2
+                14 => GetBlockField(2, 1),  // B-D1
+                15 => GetBlockField(2, 8),  // B-D2
+                16 => GetBlockField(8, 2),  // B-D3
+                17 => GetBlockField(8, 7),  // B-D4
+                
+                2 => GetBlockField(1, 2),   // A-H1
+                1 => GetBlockField(2, 3),   // A-ST
+                22 => GetBlockField(1, 7),  // C-H1
+                21 => GetBlockField(2, 6),  // C-ST
+                _ => new Vector3(0, 0, 0),
+            };
+            
+            sa.Method.TextInfo("放种子前就位", 4000, false);
 
+            if (readyPos == new Vector3(0, 0, 0))
+            {
+                sa.Log.Debug($"不应在场内的玩家却出现在了场内，真可怜！");
+                return;
+            }
+            
+            // 画方格
+            var dp0 = sa.Data.GetDefaultDrawProperties();
+            dp0.Name = $"方格{myMemberIdx}";
+            dp0.Scale = new Vector2(6, 6);
+            dp0.Position = readyPos;
+            dp0.Delay = 0;
+            dp0.DestoryAt = 7000;
+            dp0.Color = sa.Data.DefaultSafeColor;
+            sa.Method.SendDraw(DrawModeEnum.Imgui, DrawTypeEnum.Straight, dp0);
+
+            // 画指路线
+            var dp = DrawGuidance(sa, readyPos, 0, 7000, "放种子就位位置");
+            sa.Method.SendDraw(DrawModeEnum.Imgui, DrawTypeEnum.Displacement, dp);
+            sa.Log.Debug($"获得{myMemberIdx}的放种子就位位置{readyPos}");
+        }
+        
         [ScriptMethod(name: "Evil Seed 放种子绘制", eventType: EventTypeEnum.TargetIcon, eventCondition: ["Id:0227"])]
         public void EvilSeed(Event @event, ScriptAccessory accessory)
         {
@@ -1030,6 +1237,82 @@ namespace KDrawScript.Dev
         }
         
         /// <summary>
+        /// 输入实体id，判断是否带有内场Buff，判断在内场
+        /// </summary>
+        /// <param name="sa"></param>
+        /// <param name="entityId"></param>
+        /// <param name="innerPlatform">在内场</param>
+        /// <returns></returns>
+        private bool IsOnWhichPlatform(ScriptAccessory sa, ulong entityId, bool innerPlatform = true)
+        {
+            IPlayerCharacter? chara = (IPlayerCharacter?)sa.Data.Objects.SearchById(entityId);
+            if (chara == null)
+            {
+                sa.Log.Error($"输入的entityId {entityId} 未找到实例");
+                return false;
+            }
+            return chara.HasStatus(innerPlatform ? 4177u : 4178u);
+        }
+        
+        private bool IsOnInnerPlatform(ScriptAccessory sa, ulong entityId) => IsOnWhichPlatform(sa, entityId, true);
+        private bool IsOnSidePlatform(ScriptAccessory sa, ulong entityId) => IsOnWhichPlatform(sa, entityId, false);
+        
+        /// <summary>
+        /// 获得对应场地玩家字典
+        /// Key: EntityId
+        /// Value: (bool sameParty, int job(0:Tank, 1:Healer, 2:Dps, -1:Unknown), string name)
+        /// </summary>
+        /// <param name="sa"></param>
+        /// <param name="innerPlatform">是否是内场玩家</param>
+        /// <returns></returns>
+        private unsafe Dictionary<int, (bool, int, string, ulong, Vector3)> GetPlatformPlayers(ScriptAccessory sa, bool innerPlatform = true)
+        {
+            var innerPlayersDict = new Dictionary<int, (bool sameParty, int job, string name, ulong eid, Vector3 pos)>();
+            // 先找本队
+            for (int i = 0; i < sa.Data.PartyList.Count; i++)
+            {
+                // 不用foreach，避免/pdr leaveduty，导致IndexOutOfRange的崩游戏（？？？？？？）
+                var entityId = sa.Data.PartyList[i];
+                var chara = (IPlayerCharacter?)sa.Data.Objects.SearchById(entityId);
+                if (chara == null) continue;
+                if (innerPlatform ? !IsOnInnerPlatform(sa, entityId) : !IsOnSidePlatform(sa, entityId)) continue;
+
+                var job = chara.IsTank() ? 0 :
+                    chara.IsHealer() ? 1 :
+                    chara.IsDps() ? 2 :
+                    -1;
+                
+                // Dict的Key，为了与MemberIdx区分，+100
+                innerPlayersDict.Add(i + 100, (true, job, chara.Name.ToString(), entityId, chara.Position));
+            }
+            
+            // 再找团队
+            var group = GroupManager.Instance()->GetGroup(ReplayGroup);
+            for (var index = 0; index <= 1; index++)
+            {
+                for (var j = 0; j < 8; j++)
+                {
+                    var entityId = group->GetAllianceMemberByGroupAndIndex(index, j)->EntityId;
+                    var chara = (IPlayerCharacter?)sa.Data.Objects.SearchById(entityId);
+                    if (chara == null) continue;
+                    if (innerPlatform ? !IsOnInnerPlatform(sa, entityId) : !IsOnSidePlatform(sa, entityId)) continue;
+                    
+                    var job = chara.IsTank() ? 0 :
+                        chara.IsHealer() ? 1 :
+                        chara.IsDps() ? 2 :
+                        -1;
+
+                    innerPlayersDict.Add(j + 10 * (index + 1) + 100,
+                        (false, job, chara.Name.ToString(), entityId, chara.Position));
+                }
+            }
+            return innerPlayersDict;
+        }
+        
+        private Dictionary<int, (bool, int, string, ulong, Vector3)> GetInnerPlatformPlayers(ScriptAccessory sa) => GetPlatformPlayers(sa, true);
+        private Dictionary<int, (bool, int, string, ulong, Vector3)> GetSidePlatformPlayers(ScriptAccessory sa) => GetPlatformPlayers(sa, false);
+        
+        /// <summary>
         /// 返回箭头指引相关dp
         /// </summary>
         /// <param name="accessory"></param>
@@ -1088,6 +1371,183 @@ namespace KDrawScript.Dev
             object targetObj, int delay, int destroy, string name, float rotation = 0, float scale = 1f, bool isSafe = true)
             => DrawGuidance(accessory, (ulong)accessory.Data.Me, targetObj, delay, destroy, name, rotation, scale, isSafe);
 
+        public class PriorityDict
+        {
+            // ReSharper disable once NullableWarningSuppressionIsUsed
+            public ScriptAccessory sa { get; set; } = null!;
+
+            // ReSharper disable once NullableWarningSuppressionIsUsed
+            public Dictionary<int, int> Priorities { get; set; } = null!;
+            public string Annotation { get; set; } = "";
+            public int ActionCount { get; set; } = 0;
+
+            public void Init(ScriptAccessory accessory, string annotation, int partyNum = 8)
+            {
+                sa = accessory;
+                Priorities = new Dictionary<int, int>();
+                for (var i = 0; i < partyNum; i++)
+                {
+                    Priorities.Add(i, 0);
+                }
+
+                Annotation = annotation;
+                ActionCount = 0;
+            }
+
+            /// <summary>
+            /// 为特定Key增加优先级
+            /// </summary>
+            /// <param name="idx">key</param>
+            /// <param name="priority">优先级数值</param>
+            public void AddPriority(int idx, int priority)
+            {
+                Priorities[idx] += priority;
+            }
+
+            /// <summary>
+            /// 从Priorities中找到前num个数值最小的，得到新的Dict返回
+            /// </summary>
+            /// <param name="num"></param>
+            /// <returns></returns>
+            public List<KeyValuePair<int, int>> SelectSmallPriorityIndices(int num)
+            {
+                return SelectMiddlePriorityIndices(0, num);
+            }
+
+            /// <summary>
+            /// 从Priorities中找到前num个数值最大的，得到新的Dict返回
+            /// </summary>
+            /// <param name="num"></param>
+            /// <returns></returns>
+            public List<KeyValuePair<int, int>> SelectLargePriorityIndices(int num)
+            {
+                return SelectMiddlePriorityIndices(0, num, true);
+            }
+
+            /// <summary>
+            /// 从Priorities中找到升序排列中间的数值，得到新的Dict返回
+            /// </summary>
+            /// <param name="skip">跳过skip个元素。若从第二个开始取，skip=1</param>
+            /// <param name="num"></param>
+            /// <param name="descending">降序排列，默认为false</param>
+            /// <returns></returns>
+            public List<KeyValuePair<int, int>> SelectMiddlePriorityIndices(int skip, int num, bool descending = false)
+            {
+                if (Priorities.Count < skip + num)
+                    return new List<KeyValuePair<int, int>>();
+
+                IEnumerable<KeyValuePair<int, int>> sortedPriorities;
+                if (descending)
+                {
+                    // 根据值从大到小降序排序，并取前num个键
+                    sortedPriorities = Priorities
+                        .OrderByDescending(pair => pair.Value) // 先根据值排列
+                        .ThenBy(pair => pair.Key) // 再根据键排列
+                        .Skip(skip) // 跳过前skip个元素
+                        .Take(num); // 取前num个键值对
+                }
+                else
+                {
+                    // 根据值从小到大升序排序，并取前num个键
+                    sortedPriorities = Priorities
+                        .OrderBy(pair => pair.Value) // 先根据值排列
+                        .ThenBy(pair => pair.Key) // 再根据键排列
+                        .Skip(skip) // 跳过前skip个元素
+                        .Take(num); // 取前num个键值对
+                }
+
+                return sortedPriorities.ToList();
+            }
+
+            /// <summary>
+            /// 从Priorities中找到升序排列第idx位的数据，得到新的Dict返回
+            /// </summary>
+            /// <param name="idx"></param>
+            /// <param name="descending">降序排列，默认为false</param>
+            /// <returns></returns>
+            public KeyValuePair<int, int> SelectSpecificPriorityIndex(int idx, bool descending = false)
+            {
+                var sortedPriorities = SelectMiddlePriorityIndices(0, 8, descending);
+                return sortedPriorities[idx];
+            }
+
+            /// <summary>
+            /// 从Priorities中找到对应key的数据，得到其Value排序后位置返回
+            /// </summary>
+            /// <param name="key"></param>
+            /// <param name="descending">降序排列，默认为false</param>
+            /// <returns></returns>
+            public int FindPriorityIndexOfKey(int key, bool descending = false)
+            {
+                var sortedPriorities = SelectMiddlePriorityIndices(0, 8, descending);
+                var i = 0;
+                foreach (var dict in sortedPriorities)
+                {
+                    if (dict.Key == key) return i;
+                    i++;
+                }
+
+                return i;
+            }
+
+            /// <summary>
+            /// 一次性增加优先级数值
+            /// 通常适用于特殊优先级（如H-T-D-H）
+            /// </summary>
+            /// <param name="priorities"></param>
+            public void AddPriorities(List<int> priorities)
+            {
+                if (Priorities.Count != priorities.Count)
+                    throw new ArgumentException("输入的列表与内部设置长度不同");
+
+                for (var i = 0; i < Priorities.Count; i++)
+                    AddPriority(i, priorities[i]);
+            }
+
+            /// <summary>
+            /// 输出优先级字典的Key与优先级
+            /// </summary>
+            /// <returns></returns>
+            public string ShowPriorities(bool showJob = true)
+            {
+                var str = $"{Annotation} 优先级字典：\n";
+                foreach (var pair in Priorities)
+                {
+                    str += $"Key {pair.Key} {(showJob ? $"({_role[pair.Key]})" : "")}, Value {pair.Value}\n";
+                }
+
+                return str;
+            }
+            public PriorityDict DeepCopy()
+            {
+                return JsonConvert.DeserializeObject<PriorityDict>(JsonConvert.SerializeObject(this)) ??
+                       new PriorityDict();
+            }
+
+        }
+        
+        public unsafe static void SetTargetable(ScriptAccessory sa, IGameObject? obj, bool targetable)
+        {
+            if (obj == null || !obj.IsValid())
+            {
+                sa.Log.Error($"传入的IGameObject不合法。");
+                return;
+            }
+
+            GameObject* charaStruct = (GameObject*)obj.Address;
+            if (targetable)
+            {
+                if (obj.IsDead || obj.IsTargetable) return;
+                charaStruct->TargetableStatus |= ObjectTargetableFlags.IsTargetable;
+            }
+            else
+            {
+                if (!obj.IsTargetable) return;
+                charaStruct->TargetableStatus &= ~ObjectTargetableFlags.IsTargetable;
+            }
+            sa.Log.Debug($"SetTargetable {targetable} => {obj.Name} {obj}");
+        }
+        
         #endregion
     }
 }

--- a/Dawntrail/Cloud_of_Darkness_Chaotic.cs
+++ b/Dawntrail/Cloud_of_Darkness_Chaotic.cs
@@ -689,6 +689,10 @@ namespace KDrawScript.Dev
             }
         }
         
+        [ScriptMethod(name: "初始化台阶", eventType: EventTypeEnum.ActionEffect, eventCondition: ["ActionId:40449"], userControl: false)]
+        public void RecordOwner(Event @event, ScriptAccessory accessory) => TileInstance.InitOwner(accessory);
+        
+        
         [ScriptMethod(name: "开场初始就位位置", eventType: EventTypeEnum.StartCasting, eventCondition: ["ActionId:40449"],
         userControl: true)]
         public void P3InitField(Event ev, ScriptAccessory sa)

--- a/Repo.json
+++ b/Repo.json
@@ -32,12 +32,14 @@
     {
         "Name": "CoD (Chaotic) 暗黑之云诛灭战",
         "Guid": "436effd2-a350-4c67-b341-b4fe5a4ac233",
-        "Version": "0.0.1.9",
+        "Version": "0.0.2.0",
         "Author": "Due",
         "TerritoryIds": [
             1241
         ],
-        "DownloadUrl": "https://raw.githubusercontent.com/DueDine/KDrawScript/main/Dawntrail/Cloud_of_Darkness_Chaotic.cs"
+        "DownloadUrl": "https://raw.githubusercontent.com/DueDine/KDrawScript/main/Dawntrail/Cloud_of_Darkness_Chaotic.cs",
+        "Note": "当前不仅有基础绘制。以及 A/C 队 D2 - 4 指路 （即固定换到对方平台组）。\n内场组机制开发中。\n若发生问题请携ARR反馈。",
+        "UpdateInfo": "1. 加入了根据buff不可选中无法造成伤害的Boss的功能（外场坦克除外，保留挑衅大云救场的可能性）。\n2. 加入了内场种子弹指路。\n3. 加入了内场荆棘丛生拉线方向指引，及坦克待命位置。\n4. 内场组添加回旋式波动炮预占位与返回位指示。"
     },
     {
         "Name": "Jeuno The First Walk 朱诺：第一巡行",


### PR DESCRIPTION
1. 加入了根据buff不可选中无法造成伤害的Boss的功能（外场坦克除外，保留挑衅大云救场的可能性）。
2. 加入了内场种子弹指路。
3. 加入了内场荆棘丛生拉线方向指引，及坦克待命位置。
4. 内场组添加回旋式波动炮预占位与返回位指示。

此外，更改了版本号，在repo中加入了Note和UpdateInfo字段。
预览图后续补！